### PR TITLE
Fixing key vault name

### DIFF
--- a/key-vaults.tf
+++ b/key-vaults.tf
@@ -3,7 +3,7 @@ data "azurerm_client_config" "current" {}
 module "darts_key_vault" {
   source = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
 
-  name                    = format("darts-%s-kv", var.env)
+  name                    = format("darts-%s", var.env)
   product                 = var.product
   env                     = var.env
   object_id               = var.jenkins_AAD_objectId


### PR DESCRIPTION
I don't think it will match any deployed key vaults due to the suffix.

Helm adds the env as the suffix, so we need to do the same.

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
