### PR TITLE
fix: update object ID's with access to storage account

### DIFF
--- a/prod.tfvars
+++ b/prod.tfvars
@@ -3,7 +3,7 @@ address_space                   = "10.24.239.0/28"
 virtual_machine_admins          = ["675f1c23-3e46-4cf8-867b-747eb60fe89d", "d8b336b1-91fb-4fa6-bbe2-1f197c0d52c8", "14f9cf0e-8327-4f12-9d2c-f7e7eb05629d", "50132661-6997-484e-b0fd-5ec1052afabb", "e7ea2042-4ced-45dd-8ae3-e051c6551789"]
 virtual_machine_users           = []
 firewall_address_space          = "10.24.239.128/26"
-storage_account_contributor_ids = ["675f1c23-3e46-4cf8-867b-747eb60fe89d", "d8b336b1-91fb-4fa6-bbe2-1f197c0d52c8", "14f9cf0e-8327-4f12-9d2c-f7e7eb05629d", "50132661-6997-484e-b0fd-5ec1052afabb", "e7ea2042-4ced-45dd-8ae3-e051c6551789"]
+storage_account_contributor_ids = ["87c8cf3d-ff9d-4d8f-8430-ccc737764435"]
 
 firewall_network_rules = {
   darts-migration-prod = {

--- a/stg.tfvars
+++ b/stg.tfvars
@@ -3,7 +3,7 @@ address_space                   = "10.24.239.64/28"
 virtual_machine_admins          = ["675f1c23-3e46-4cf8-867b-747eb60fe89d", "d8b336b1-91fb-4fa6-bbe2-1f197c0d52c8", "14f9cf0e-8327-4f12-9d2c-f7e7eb05629d", "50132661-6997-484e-b0fd-5ec1052afabb", "e7ea2042-4ced-45dd-8ae3-e051c6551789", "cd395cb0-35d7-454b-8c99-26422f78901e"]
 virtual_machine_users           = []
 firewall_address_space          = "10.24.239.192/26"
-storage_account_contributor_ids = ["675f1c23-3e46-4cf8-867b-747eb60fe89d", "d8b336b1-91fb-4fa6-bbe2-1f197c0d52c8", "14f9cf0e-8327-4f12-9d2c-f7e7eb05629d", "50132661-6997-484e-b0fd-5ec1052afabb", "e7ea2042-4ced-45dd-8ae3-e051c6551789", "cd395cb0-35d7-454b-8c99-26422f78901e"]
+storage_account_contributor_ids = ["87c8cf3d-ff9d-4d8f-8430-ccc737764435"]
 
 firewall_network_rules = {
   darts-migration-stg = {


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Update the object ID's of the principals allowed to access storage accounts.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
