### PR TITLE
fix: specify Entra ID Domain Services as the DNS Servers for the migration vnet

### DIFF
--- a/networking.tf
+++ b/networking.tf
@@ -6,7 +6,7 @@ resource "azurerm_virtual_network" "migration" {
   resource_group_name = azurerm_resource_group.darts_migration_resource_group[0].name
 
   dns_servers = ["10.128.0.4", "10.128.0.5"]
-  tags                = var.common_tags
+  tags        = var.common_tags
 }
 
 moved {

--- a/networking.tf
+++ b/networking.tf
@@ -4,6 +4,8 @@ resource "azurerm_virtual_network" "migration" {
   address_space       = concat([var.address_space, var.postgres_subnet_address_space], local.palo_address_space)
   location            = azurerm_resource_group.darts_migration_resource_group[0].location
   resource_group_name = azurerm_resource_group.darts_migration_resource_group[0].name
+
+  dns_servers = ["10.128.0.4", "10.128.0.5"]
   tags                = var.common_tags
 }
 


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-16629


### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
