### PR TITLE
feat-defender-scanning-cap

### DIFF
--- a/migration-blob-storage.tf
+++ b/migration-blob-storage.tf
@@ -17,7 +17,7 @@ module "sa-migration-standard" {
   enable_versioning                 = false
   defender_enabled                  = var.defender_enable
   defender_malware_scanning_enabled = var.defender_scan
-  defender_malware_scanning_cap_gb_per_month = 10000
+  defender_malware_scanning_cap_gb_per_month = 150000
   common_tags                       = var.common_tags
 }
 

--- a/migration-blob-storage.tf
+++ b/migration-blob-storage.tf
@@ -17,6 +17,7 @@ module "sa-migration-standard" {
   enable_versioning                 = false
   defender_enabled                  = var.defender_enable
   defender_malware_scanning_enabled = var.defender_scan
+  defender_malware_scanning_cap_gb_per_month = 10000
   common_tags                       = var.common_tags
 }
 


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###
Migration team have estimated a further 600tb to be uploaded to this storage account over the next 6 months, so raised the cap to 150tb to avoid security team being alerted at 75% each month. 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
