### PR TITLE
DMP-1868 - Add a new add audio request size value into the vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Darts modernisation application shared infrastructure
 Shared Vault Keys
 -----------------
 *****
-| Vault Key                    | Type  | Description                                   | Consumed by                                    | Default Value |
-|------------------------------|-------|-----------------------------------------------|------------------------------------------------|---------------|
-| MaxFileUploadSizeInMegabytes | Long  | Describes the Megabyte limit on file uploads  | Modernised Gateway Service / Darts API Service | 350MB         | 
+| Vault Key                           | Type  | Description                                   | Consumed by                                    | Default Value |
+|-------------------------------------|-------|-----------------------------------------------|------------------------------------------------|---------------|
+| MaxFileUploadSizeInMegabytes        | Long  | Describes the Megabyte limit on file uploads  | Modernised Gateway Service / Darts API Service | 350MB         | 
+| MaxFileUploadRequestSizeInMegabytes | Long  | Describes the Megabyte limit on file requests | Darts API Service                              | 360MB         | 

--- a/key-vaults.tf
+++ b/key-vaults.tf
@@ -21,6 +21,12 @@ resource "azurerm_key_vault_secret" "MaxFileUploadSizeInMegabytes" {
   key_vault_id = module.darts_key_vault.key_vault_id
 }
 
+resource "azurerm_key_vault_secret" "MaxFileUploadRequestSizeInMegabytes" {
+  name         = "MaxFileUploadRequestSizeInMegabytes"
+  value        = var.max-file-upload-request-megabytes
+  key_vault_id = module.darts_key_vault.key_vault_id
+}
+
 module "darts_migration_key_vault" {
   count  = local.is_migration_environment ? 1 : 0
   source = "git@github.com:hmcts/cnp-module-key-vault?ref=master"

--- a/variables.tf
+++ b/variables.tf
@@ -279,3 +279,9 @@ variable "max-file-upload-megabytes" {
   default     = "350"
   description = "The file upload size threshold in megabytes "
 }
+
+variable "max-file-upload-request-megabytes" {
+  type        = number
+  default     = "360"
+  description = "The file upload request size threshold in megabytes "
+}


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DMP-1868

### Change description ###

Allows us to represent both the file upload size and the overall request size in the Azure vault

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x ] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
