### PR TITLE
feat-malware-scanning-cap

### DIFF
--- a/migration-blob-storage.tf
+++ b/migration-blob-storage.tf
@@ -17,7 +17,7 @@ module "sa-migration-standard" {
   enable_versioning                          = false
   defender_enabled                           = var.defender_enable
   defender_malware_scanning_enabled          = var.defender_scan
-  defender_malware_scanning_cap_gb_per_month = 150000
+  defender_malware_scanning_cap_gb_per_month = 250000
   common_tags                                = var.common_tags
 }
 


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###
increase the malware scanning cap to 25000 gb per month on the migration storage account

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
